### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/sentry/SentryAlert.java
+++ b/src/main/java/io/kestra/plugin/sentry/SentryAlert.java
@@ -122,6 +122,7 @@ public class SentryAlert extends AbstractSentryConnection {
         description = "Project DSN used to authenticate requests; keep in secrets and follow Sentry DSN format."
     )
     @PluginProperty(dynamic = true, group = "main", secret = true)
+    @ToString.Exclude
     @NotBlank
     protected String dsn;
 
@@ -168,7 +169,7 @@ public class SentryAlert extends AbstractSentryConnection {
 
             // Trying to send to /envelope endpoint
             try {
-                runContext.logger().debug("Attempting to send the following Sentry event envelope: {}", envelope);
+                runContext.logger().debug("Attempting to send the following Sentry event envelope: {}", redactDsn(envelope, dsn));
                 HttpRequest.HttpRequestBuilder requestBuilder = createRequestBuilder(runContext)
                     .addHeader("Content-Type", "application/json")
                     .uri(URI.create(url))
@@ -233,6 +234,17 @@ public class SentryAlert extends AbstractSentryConnection {
      */
     private static String getItemHeaders(int payloadLength) {
         return "{\"type\":\"%s\",\"length\":%d,\"content_type\":\"%s\",\"filename\":\"%s\"}".formatted(SENTRY_DATA_MODEL, payloadLength, SENTRY_CONTENT_TYPE, SENTRY_FILE_NAME);
+    }
+
+    /**
+     * Helper method to redact the DSN (which contains the Sentry secret API key) from a string
+     * before it is written to logs. Never log the raw envelope/DSN at any level.
+     */
+    private static String redactDsn(String value, String dsn) {
+        if (value == null || dsn == null || dsn.isEmpty()) {
+            return value;
+        }
+        return value.replace(dsn, "***REDACTED***");
     }
 
     /**


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Sentry DSN (API key) written to task logs at DEBUG level — `src/main/java/io/kestra/plugin/sentry/SentryAlert.java:171` — The full envelope (which embeds the DSN) is now redacted via a new `redactDsn()` helper before being passed to `runContext.logger().debug()`, so the secret DSN is never written to task logs.
- **MEDIUM** — Sentry DSN exposed via Lombok `@ToString` on `SentryAlert` and subclasses — `src/main/java/io/kestra/plugin/sentry/SentryAlert.java:28` — Added `@ToString.Exclude` on the `dsn` field so it is omitted from the generated `toString()` (inherited by `SentryTemplate`), in addition to its existing `@PluginProperty(secret = true)` annotation.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-sentry/issues/41
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
